### PR TITLE
Fix build, add CI workflows, global tool packaging, and cross-platform improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,32 +8,24 @@ on:
       - '**/*.md'
       - '**/*.gitignore'
       - '**/*.gitattributes'
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.gitignore'
-      - '**/*.gitattributes'
   workflow_dispatch:
-    branches:
-      - main
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.gitignore'
-      - '**/*.gitattributes'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     name: Build
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_NOLOGO: true
-      DOTNET_GENERATE_ASPNET_CERTIFICATE: false
-      DOTNET_ADD_GLOBAL_TOOLS_TO_PATH: false
-      DOTNET_MULTILEVEL_LOOKUP: 0
     defaults:
       run:
        working-directory: src/DeckSurf
@@ -46,11 +38,8 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
-    - name: Restore
-      run: dotnet restore
-
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build DeckSurf.sln --configuration Release
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     timeout-minutes: 15
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -38,8 +38,11 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
+    - name: Restore
+      run: dotnet restore DeckSurf.sln
+
     - name: Build
-      run: dotnet build DeckSurf.sln --configuration Release
+      run: dotnet build DeckSurf.sln --configuration Release --no-restore
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     timeout-minutes: 15
     steps:
     - name: Checkout
@@ -27,6 +27,9 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '10.0.x'
+    - name: Restore
+      working-directory: src/DeckSurf
+      run: dotnet restore DeckSurf.sln
     - name: Build
       working-directory: src/DeckSurf
-      run: dotnet build DeckSurf.sln --configuration Release
+      run: dotnet build DeckSurf.sln --configuration Release --no-restore

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -28,5 +28,5 @@ jobs:
       with:
         dotnet-version: '10.0.x'
     - name: Build
-      working-directory: ./src/DeckSurf
+      working-directory: src/DeckSurf
       run: dotnet build DeckSurf.sln --configuration Release

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,32 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.gitignore'
+      - '**/*.gitattributes'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '10.0.x'
+    - name: Build
+      working-directory: ./src/DeckSurf
+      run: dotnet build DeckSurf.sln --configuration Release

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,7 +3,7 @@ name: Publish NuGet Package
 on:
   push:
     tags:
-    - "[0-9]+.[0-9]+.[0-9]+*"
+    - "[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     timeout-minutes: 15
     steps:
     - name: Checkout
@@ -29,18 +29,21 @@ jobs:
         git branch --remote --contains | grep origin/main
     - name: Set VERSION variable from tag
       run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      shell: bash
+    - name: Restore
+      working-directory: src/DeckSurf
+      run: dotnet restore DeckSurf.sln
     - name: Build
       working-directory: src/DeckSurf
-      run: dotnet build DeckSurf.sln --configuration Release /p:Version=${VERSION}
+      run: dotnet build DeckSurf.sln --configuration Release --no-restore /p:Version=${{ env.VERSION }}
     - name: Pack
       working-directory: src/DeckSurf/DeckSurf
-      run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output .
+      run: dotnet pack --configuration Release /p:Version=${{ env.VERSION }} --no-build --output .
     - name: Upload Package Artifacts
       uses: actions/upload-artifact@v4
       with:
         name: nuget-packages
-        path: |
-          src/DeckSurf/DeckSurf/*.nupkg
+        path: src/DeckSurf/DeckSurf/*.nupkg
     - name: Push
       working-directory: src/DeckSurf/DeckSurf
-      run: dotnet nuget push DeckSurf.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+      run: dotnet nuget push "DeckSurf.${{ env.VERSION }}.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,46 @@
+name: Publish NuGet Package
+
+on:
+  push:
+    tags:
+    - "[0-9]+.[0-9]+.[0-9]+*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-nuget-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '10.0.x'
+    - name: Verify commit exists in origin/main
+      run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        git branch --remote --contains | grep origin/main
+    - name: Set VERSION variable from tag
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    - name: Build
+      working-directory: ./src/DeckSurf
+      run: dotnet build DeckSurf.sln --configuration Release /p:Version=${VERSION}
+    - name: Pack
+      working-directory: ./src/DeckSurf/DeckSurf
+      run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output .
+    - name: Upload Package Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-packages
+        path: |
+          src/DeckSurf/DeckSurf/*.nupkg
+    - name: Push
+      working-directory: ./src/DeckSurf/DeckSurf
+      run: dotnet nuget push DeckSurf.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -30,10 +30,10 @@ jobs:
     - name: Set VERSION variable from tag
       run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Build
-      working-directory: ./src/DeckSurf
+      working-directory: src/DeckSurf
       run: dotnet build DeckSurf.sln --configuration Release /p:Version=${VERSION}
     - name: Pack
-      working-directory: ./src/DeckSurf/DeckSurf
+      working-directory: src/DeckSurf/DeckSurf
       run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output .
     - name: Upload Package Artifacts
       uses: actions/upload-artifact@v4
@@ -42,5 +42,5 @@ jobs:
         path: |
           src/DeckSurf/DeckSurf/*.nupkg
     - name: Push
-      working-directory: ./src/DeckSurf/DeckSurf
+      working-directory: src/DeckSurf/DeckSurf
       run: dotnet nuget push DeckSurf.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -64,14 +64,13 @@ Usage:
   deck write [options] 
 
 Options:
-  -d, --device-index <device-index> (REQUIRED)  Index of the connected device, to which a key setting should be
-                                                written. [default: -1]
-  -k, --key-index <key-index> (REQUIRED)        Index of the key that needs to be written. [default: -1]
-  -n, --plugin <plugin> (REQUIRED)              Plugin that contains the relevant command. [default: ]
-  -c, --command <command> (REQUIRED)            Command to be executed. [default: ]
+  -d, --device-index <device-index> (REQUIRED)  Zero-based index of the connected device. [default: -1]
+  -k, --key-index <key-index> (REQUIRED)        Zero-based index of the key to configure. [default: -1]
+  -n, --plugin <plugin> (REQUIRED)              Plugin ID (e.g., DeckSurf.Plugin.Barn). [default: ]
+  -c, --command <command> (REQUIRED)            Command class name within the plugin. [default: ]
   -i, --image-path <image-path> (REQUIRED)      Path to the default image for the button. [default: ]
-  -a, --action-args <action-args> (REQUIRED)    Arguments for the defined action. [default: ]
-  -p, --profile <profile> (REQUIRED)            The profile to which the command should be added. [default: ]
+  -a, --action-args <action-args> (REQUIRED)    Arguments passed to the command. [default: ]
+  -p, --profile <profile> (REQUIRED)            Profile name. Created if it does not exist. [default: ]
   -?, -h, --help                                Show help and usage information
 ```
 
@@ -120,7 +119,7 @@ Launches an application when the mapped button is pressed. On activation, it aut
 **Usage example:**
 
 ```bash
-deck write -d 0 -k 5 -l DeckSurf.Plugin.Barn -c LaunchApplication -i "" -g "C:\Windows\System32\notepad.exe" -p myprofile
+deck write -d 0 -k 5 -n DeckSurf.Plugin.Barn -c LaunchApplication -i "" -a "C:\Windows\System32\notepad.exe" -p myprofile
 ```
 
 The `--action-args` (`-g`) value is the full path to the executable to launch.
@@ -132,7 +131,7 @@ Displays a live-updating system-wide CPU usage percentage on the mapped button. 
 **Usage example:**
 
 ```bash
-deck write -d 0 -k 10 -l DeckSurf.Plugin.Barn -c ShowCPUUsage -i "" -g "" -p myprofile
+deck write -d 0 -k 10 -n DeckSurf.Plugin.Barn -c ShowCPUUsage -i "" -a "" -p myprofile
 ```
 
 No arguments are required for this command.
@@ -144,7 +143,7 @@ A fully playable game of snake that runs on the Stream Deck button grid. The sna
 **Usage example:**
 
 ```bash
-deck write -d 0 -k 0 -l DeckSurf.Plugin.Barn -c SnakeGame -i "" -g "" -p myprofile
+deck write -d 0 -k 0 -n DeckSurf.Plugin.Barn -c SnakeGame -i "" -a "" -p myprofile
 ```
 
 The game uses the device's full button grid (e.g., 8x4 on the XL). Snake segments are displayed as white buttons and empty space is black.

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Options:
   -d, --device-index <device-index> (REQUIRED)  Index of the connected device, to which a key setting should be
                                                 written. [default: -1]
   -k, --key-index <key-index> (REQUIRED)        Index of the key that needs to be written. [default: -1]
-  -l, --plugin <plugin> (REQUIRED)              Plugin that contains the relevant command. [default: ]
+  -n, --plugin <plugin> (REQUIRED)              Plugin that contains the relevant command. [default: ]
   -c, --command <command> (REQUIRED)            Command to be executed. [default: ]
   -i, --image-path <image-path> (REQUIRED)      Path to the default image for the button. [default: ]
-  -g, --action-args <action-args> (REQUIRED)    Arguments for the defined action. [default: ]
+  -a, --action-args <action-args> (REQUIRED)    Arguments for the defined action. [default: ]
   -p, --profile <profile> (REQUIRED)            The profile to which the command should be added. [default: ]
   -?, -h, --help                                Show help and usage information
 ```
@@ -81,10 +81,10 @@ The following arguments are used, and are required:
 |:-------------------------|:------------|
 | `--device-index` or `-d` | Zero-based index of the connected Stream Deck device. If only one device is connected, the index is `0`. |
 | `--key-index` or `-k`    | Zero-based index of the key that is being written to. Should be within the boundaries of the keys for the connected device. |
-| `--plugin` or `-l`       | The full identifier of the DeckSurf plugin that will be used for command handling. Should match the name of the plugin DLL, without the file extension. |
+| `--plugin` or `-n`       | The full identifier of the DeckSurf plugin that will be used for command handling. Should match the plugin ID (e.g., `DeckSurf.Plugin.Barn`). |
 | `--command` or `-c`      | Command identifier. Should match the name of the command class in the plugin assembly. |
 | `--image-path` or `-i`   | Path to the image that will be used for the button that is being written to. This can be the default image, that will be replaced later on through one of the commands. |
-| `--action-args` or `-g`  | Arguments to pass to the command being executed. This string is specific to each command. |
+| `--action-args` or `-a`  | Arguments to pass to the command being executed. This string is specific to each command. |
 | `--profile` or `-p`      | The name of the profile to be used. If no profile with a given name exists, a new one will be created. |
 
 The created profile will be located in `%LOCALAPPDATA%\Den.Dev\DeckSurf\Profiles\{PROFILE_NAME}`. The settings are stored in a `profile.json` file within the profile folder.
@@ -93,15 +93,15 @@ The created profile will be located in `%LOCALAPPDATA%\Den.Dev\DeckSurf\Profiles
 
 | Command        | Description |
 |:---------------|:------------|
-| `deck write`   | Write a button configuration to a profile. |
-| `deck list`    | List all connected Stream Deck devices. |
-| `deck list-plugins` | List all available plugins and their commands. |
-| `deck listen`  | Start listening for button presses on a configured profile. |
+| `deck devices list` | List all connected Stream Deck devices. |
+| `deck devices info` | Show detailed information about a connected device. |
+| `deck devices brightness` | Set the brightness level of a connected device. |
+| `deck plugins list` | List all available plugins and their commands. |
 | `deck profiles list` | List all saved profiles. |
 | `deck profiles show <name>` | Show details and button mappings for a profile. |
 | `deck profiles delete <name>` | Delete a saved profile. |
-| `deck info`    | Show detailed information about a connected device. |
-| `deck brightness` | Set the brightness level of a connected device. |
+| `deck write`   | Write a button configuration to a profile. |
+| `deck listen`  | Start listening for button presses on a configured profile. |
 
 ## Included Plugin: Barn
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@
 	<p><a href="https://github.com/dend/decksurf-sdk">Software Development Kit</a> | <a href="https://docs.deck.surf">Documentation</a></p>
 </div>
 
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [How It Works](#how-it-works)
+- [Available CLI Commands](#available-cli-commands)
+- [Included Plugin: Barn](#included-plugin-barn)
+  - [LaunchApplication](#launchapplication)
+  - [ShowCPUUsage](#showcpuusage)
+  - [SnakeGame](#snakegame)
+- [Building a Plugin](#building-a-plugin)
+  - [Plugin Interface](#plugin-interface)
+  - [Command Interface](#command-interface)
+  - [Key SDK Types](#key-sdk-types)
+  - [Plugin Deployment](#plugin-deployment)
+- [Supported Devices](#supported-devices)
+- [FAQ](#faq)
+
 ## Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
@@ -63,6 +80,57 @@ The created profile will be located in `%LOCALAPPDATA%\Den.Dev\DeckSurf\Profiles
 | `deck list`    | List all connected Stream Deck devices. |
 | `deck list-plugins` | List all available plugins and their commands. |
 | `deck listen`  | Start listening for button presses on a configured profile. |
+| `deck profiles list` | List all saved profiles. |
+| `deck profiles show <name>` | Show details and button mappings for a profile. |
+| `deck profiles delete <name>` | Delete a saved profile. |
+| `deck info`    | Show detailed information about a connected device. |
+| `deck brightness` | Set the brightness level of a connected device. |
+
+## Included Plugin: Barn
+
+DeckSurf ships with **DeckSurf.Plugin.Barn**, a built-in plugin that demonstrates the plugin system and provides useful commands out of the box. All Barn commands are currently compatible with the Stream Deck XL.
+
+| Command | Description |
+|:--------|:------------|
+| `LaunchApplication` | Launch any application from a Stream Deck button. |
+| `ShowCPUUsage` | Display live CPU usage percentage on a button. |
+| `SnakeGame` | Play a game of snake directly on the Stream Deck button grid. |
+
+### LaunchApplication
+
+Launches an application when the mapped button is pressed. On activation, it automatically extracts the file icon from the target executable and displays it on the button (Windows only). If a custom `--image-path` is provided in the profile, that image is used instead.
+
+**Usage example:**
+
+```bash
+deck write -d 0 -k 5 -l DeckSurf.Plugin.Barn -c LaunchApplication -i "" -g "C:\Windows\System32\notepad.exe" -p myprofile
+```
+
+The `--action-args` (`-g`) value is the full path to the executable to launch.
+
+### ShowCPUUsage
+
+Displays a live-updating CPU usage percentage on the mapped button. The display refreshes every 2 seconds, rendering the current percentage as red text on a black background. This command uses Windows Performance Counters and is Windows-only.
+
+**Usage example:**
+
+```bash
+deck write -d 0 -k 10 -l DeckSurf.Plugin.Barn -c ShowCPUUsage -i "" -g "" -p myprofile
+```
+
+No arguments are required for this command.
+
+### SnakeGame
+
+A fully playable game of snake that runs on the Stream Deck button grid. The snake moves automatically once per second, and you steer it by pressing buttons on the device. Press a button above or below the snake's head to change vertical direction, or left/right to change horizontal direction. The snake wraps around the edges of the grid.
+
+**Usage example:**
+
+```bash
+deck write -d 0 -k 0 -l DeckSurf.Plugin.Barn -c SnakeGame -i "" -g "" -p myprofile
+```
+
+The game uses the device's full button grid (e.g., 8x4 on the XL). Snake segments are displayed as white buttons and empty space is black.
 
 ## Building a Plugin
 
@@ -156,7 +224,7 @@ The Stream Deck Plus and Neo also support LCD screen output via `IConnectedDevic
 
 ### Why was this project created?
 
-The Stream Deck is a great piece of hardware, but the official software is closed-source and opaque. DeckSurf was created to build an open, hackable alternative — by reverse engineering the USB HID protocol that the Stream Deck uses, we can give developers and tinkerers full control over their devices without relying on proprietary tooling. The goal is an open ecosystem where anyone can extend, automate, and integrate their Stream Deck however they see fit.
+The Stream Deck is a great piece of hardware, but the official software is closed-source and opaque. I created DeckSurf to build an open, hackable alternative — by reverse engineering the USB HID protocol that the Stream Deck uses, I wanted to give developers and tinkerers full control over their devices without relying on proprietary tooling. The goal is an open ecosystem where anyone can extend, automate, and integrate their Stream Deck however they see fit.
 
 ### Is this official/endorsed by Elgato?
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The `--action-args` (`-g`) value is the full path to the executable to launch.
 
 ### ShowCPUUsage
 
-Displays a live-updating CPU usage percentage on the mapped button. The display refreshes every 2 seconds, rendering the current percentage as red text on a black background. This command uses Windows Performance Counters and is Windows-only.
+Displays a live-updating system-wide CPU usage percentage on the mapped button. The display refreshes every 2 seconds. On Windows, the percentage is rendered as red text on a black background. On macOS and Linux, the button color shifts from green (low usage) through yellow to red (high usage).
 
 **Usage example:**
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The created profile will be located in `%LOCALAPPDATA%\Den.Dev\DeckSurf\Profiles
 
 ## Included Plugin: Barn
 
-DeckSurf ships with **DeckSurf.Plugin.Barn**, a built-in plugin that demonstrates the plugin system and provides useful commands out of the box. All Barn commands are currently compatible with the Stream Deck XL.
+DeckSurf ships with **DeckSurf.Plugin.Barn**, a built-in plugin that demonstrates the plugin system and provides useful commands out of the box. All Barn commands are compatible with every supported Stream Deck model.
 
 | Command | Description |
 |:--------|:------------|

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 ## Table of Contents
 
+- [Installation](#installation)
 - [Prerequisites](#prerequisites)
 - [How It Works](#how-it-works)
 - [Available CLI Commands](#available-cli-commands)
@@ -29,6 +30,22 @@
   - [Plugin Deployment](#plugin-deployment)
 - [Supported Devices](#supported-devices)
 - [FAQ](#faq)
+
+## Installation
+
+DeckSurf is distributed as a .NET global tool. Install it with:
+
+```bash
+dotnet tool install -g DeckSurf
+```
+
+Once installed, the `deck` command is available from any terminal. To update to the latest version:
+
+```bash
+dotnet tool update -g DeckSurf
+```
+
+The tool includes the Barn plugin out of the box, so you can start using commands like `LaunchApplication`, `ShowCPUUsage`, and `SnakeGame` immediately.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The Stream Deck Plus and Neo also support LCD screen output via `IConnectedDevic
 
 ### Why was this project created?
 
-I was fiddling with the default Stream Deck software, and realized that it [was constantly scanning my registry and process tree](https://twitter.com/DennisCode/status/1401230392527523856). According to Elgato support, this is necessary for [Smart Profiles](https://help.elgato.com/hc/en-us/articles/360053419071-Elgato-Stream-Deck-Smart-Profiles); however, the process monitoring occurs even when Smart Profiles are not configured. While the feature itself is nice, I wasn't too comfortable with some software constantly monitoring what I run without a way to disable that, so I decided to tinker with the device and see if I can figure out how to write my own software that manages the Stream Deck device.
+The Stream Deck is a great piece of hardware, but the official software is closed-source and opaque. DeckSurf was created to build an open, hackable alternative — by reverse engineering the USB HID protocol that the Stream Deck uses, we can give developers and tinkerers full control over their devices without relying on proprietary tooling. The goal is an open ecosystem where anyone can extend, automate, and integrate their Stream Deck however they see fit.
 
 ### Is this official/endorsed by Elgato?
 

--- a/src/DeckSurf/.editorconfig
+++ b/src/DeckSurf/.editorconfig
@@ -1,4 +1,48 @@
-﻿[*.cs]
+root = true
 
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+# Naming conventions
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_style.camel_case.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
+
+# Private fields should be _camelCase
+dotnet_naming_rule.private_fields_should_be_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_camel_case.style = prefix_underscore
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+# Code style
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_prefer_braces = true:suggestion
+csharp_new_line_before_open_brace = all
+csharp_indent_case_contents = true
+
+# Formatting
+dotnet_sort_system_directives_first = true
+
+# Analyzer suppressions
 # CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.CA1707.severity = none
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.xml]
+indent_size = 2

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/LaunchApplication.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/LaunchApplication.cs
@@ -27,7 +27,7 @@ namespace DeckSurf.Plugin.Barn.Commands
             Process.Start(new ProcessStartInfo
             {
                 FileName = mappedCommand.CommandArguments,
-                UseShellExecute = true,
+                UseShellExecute = false,
             });
         }
 

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/LaunchApplication.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/LaunchApplication.cs
@@ -20,7 +20,7 @@ namespace DeckSurf.Plugin.Barn.Commands
     class LaunchApplication : IDeckSurfCommand
     {
         public string Name => "Launch Application";
-        public string Description => "Launches an application on the machine.";
+        public string Description => "Launches an application from a Stream Deck button.";
 
         public void ExecuteOnAction(CommandMapping mappedCommand, IConnectedDevice mappedDevice, int activatingButton = -1)
         {

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/LaunchApplication.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/LaunchApplication.cs
@@ -24,11 +24,24 @@ namespace DeckSurf.Plugin.Barn.Commands
 
         public void ExecuteOnAction(CommandMapping mappedCommand, IConnectedDevice mappedDevice, int activatingButton = -1)
         {
-            Process.Start(new ProcessStartInfo
+            if (OperatingSystem.IsMacOS())
             {
-                FileName = mappedCommand.CommandArguments,
-                UseShellExecute = false,
-            });
+                // macOS needs 'open' to launch .app bundles.
+                Process.Start("open", mappedCommand.CommandArguments);
+            }
+            else if (OperatingSystem.IsLinux())
+            {
+                // Linux needs 'xdg-open' to handle desktop files and URLs.
+                Process.Start("xdg-open", mappedCommand.CommandArguments);
+            }
+            else
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = mappedCommand.CommandArguments,
+                    UseShellExecute = false,
+                });
+            }
         }
 
         public void ExecuteOnActivation(CommandMapping mappedCommand, IConnectedDevice mappedDevice)

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/LaunchApplication.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/LaunchApplication.cs
@@ -9,6 +9,14 @@ using System.IO;
 namespace DeckSurf.Plugin.Barn.Commands
 {
     [CompatibleWith(DeviceModel.XL)]
+    [CompatibleWith(DeviceModel.XL2022)]
+    [CompatibleWith(DeviceModel.Original)]
+    [CompatibleWith(DeviceModel.Original2019)]
+    [CompatibleWith(DeviceModel.MK2)]
+    [CompatibleWith(DeviceModel.Mini)]
+    [CompatibleWith(DeviceModel.Mini2022)]
+    [CompatibleWith(DeviceModel.Plus)]
+    [CompatibleWith(DeviceModel.Neo)]
     class LaunchApplication : IDeckSurfCommand
     {
         public string Name => "Launch Application";

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/LaunchApplication.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/LaunchApplication.cs
@@ -1,10 +1,10 @@
 using DeckSurf.SDK.Interfaces;
 using DeckSurf.SDK.Models;
 using DeckSurf.SDK.Util;
+using System;
 using System.Diagnostics;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
+using System.Runtime.Versioning;
 
 namespace DeckSurf.Plugin.Barn.Commands
 {
@@ -33,28 +33,83 @@ namespace DeckSurf.Plugin.Barn.Commands
 
         public void ExecuteOnActivation(CommandMapping mappedCommand, IConnectedDevice mappedDevice)
         {
-            if (string.IsNullOrEmpty(mappedCommand.ButtonImagePath))
+            if (!string.IsNullOrEmpty(mappedCommand.ButtonImagePath))
             {
-                try
+                return;
+            }
+
+            try
+            {
+                byte[] imageBytes = null;
+
+                if (OperatingSystem.IsWindows())
                 {
-                    using var bitmap = ImageHelper.GetFileIcon(mappedCommand.CommandArguments, mappedDevice.ButtonResolution, mappedDevice.ButtonResolution, SIIGBF.SIIGBF_ICONONLY | SIIGBF.SIIGBF_CROPTOSQUARE);
-
-                    byte[] byteContent;
-                    using (var ms = new MemoryStream())
-                    {
-                        bitmap.Save(ms, ImageFormat.Png);
-                        byteContent = ms.ToArray();
-                    }
-
-                    var resizedByteContent = ImageHelper.ResizeImage(byteContent, mappedDevice.ButtonResolution, mappedDevice.ButtonResolution, mappedDevice.ImageRotation, mappedDevice.KeyImageFormat);
-                    mappedDevice.SetKey(mappedCommand.ButtonIndex, resizedByteContent);
+                    imageBytes = TryGetWindowsFileIcon(mappedCommand.CommandArguments, mappedDevice);
                 }
-                catch
+
+                if (imageBytes == null)
                 {
-                    // Could not set up the right configuration for the button image.
-                    Debug.WriteLine($"Could not set icon for {mappedCommand.CommandArguments}");
+                    // Cross-platform fallback: use a custom image if the command
+                    // argument points to an image file, otherwise set a colored key.
+                    var arg = mappedCommand.CommandArguments;
+                    if (File.Exists(arg) && IsImageFile(arg))
+                    {
+                        imageBytes = File.ReadAllBytes(arg);
+                    }
+                }
+
+                if (imageBytes != null)
+                {
+                    var resized = ImageHelper.ResizeImage(
+                        imageBytes,
+                        mappedDevice.ButtonResolution,
+                        mappedDevice.ButtonResolution,
+                        mappedDevice.ImageRotation,
+                        mappedDevice.KeyImageFormat);
+                    mappedDevice.SetKey(mappedCommand.ButtonIndex, resized);
+                }
+                else
+                {
+                    // No icon available — set a recognizable colored key.
+                    mappedDevice.SetKeyColor(mappedCommand.ButtonIndex, DeviceColor.Cyan);
                 }
             }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Could not set icon for {mappedCommand.CommandArguments}: {ex.Message}");
+                mappedDevice.SetKeyColor(mappedCommand.ButtonIndex, DeviceColor.Cyan);
+            }
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static byte[] TryGetWindowsFileIcon(string filePath, IConnectedDevice device)
+        {
+            try
+            {
+                using var bitmap = ImageHelper.GetFileIcon(
+                    filePath,
+                    device.ButtonResolution,
+                    device.ButtonResolution,
+                    SIIGBF.SIIGBF_ICONONLY | SIIGBF.SIIGBF_CROPTOSQUARE);
+
+                using var ms = new MemoryStream();
+                bitmap.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                return ms.ToArray();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static bool IsImageFile(string path)
+        {
+            var ext = Path.GetExtension(path);
+            return ext.Equals(".png", StringComparison.OrdinalIgnoreCase)
+                || ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+                || ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
+                || ext.Equals(".bmp", StringComparison.OrdinalIgnoreCase)
+                || ext.Equals(".gif", StringComparison.OrdinalIgnoreCase);
         }
 
         public void Dispose()

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/ShowCPUUsage.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/ShowCPUUsage.cs
@@ -30,7 +30,7 @@ namespace DeckSurf.Plugin.Barn.Commands
         private System.Timers.Timer _cpuUsageTimer;
 
         public string Name => "Show CPU Usage";
-        public string Description => "Shows % of the CPU being used. Windows only.";
+        public string Description => "Displays live CPU usage percentage on a Stream Deck button. Windows only.";
 
         public void ExecuteOnAction(CommandMapping mappedCommand, IConnectedDevice mappedDevice, int activatingButton = -1)
         {

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/ShowCPUUsage.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/ShowCPUUsage.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Threading;
 
 namespace DeckSurf.Plugin.Barn.Commands
@@ -19,6 +20,7 @@ namespace DeckSurf.Plugin.Barn.Commands
     [CompatibleWith(DeviceModel.Mini2022)]
     [CompatibleWith(DeviceModel.Plus)]
     [CompatibleWith(DeviceModel.Neo)]
+    [SupportedOSPlatform("windows")]
     class ShowCPUUsage : IDeckSurfCommand
     {
         private const string CategoryName = "Processor";
@@ -28,7 +30,7 @@ namespace DeckSurf.Plugin.Barn.Commands
         private System.Timers.Timer _cpuUsageTimer;
 
         public string Name => "Show CPU Usage";
-        public string Description => "Shows % of the CPU being used.";
+        public string Description => "Shows % of the CPU being used. Windows only.";
 
         public void ExecuteOnAction(CommandMapping mappedCommand, IConnectedDevice mappedDevice, int activatingButton = -1)
         {
@@ -63,7 +65,6 @@ namespace DeckSurf.Plugin.Barn.Commands
             _cpuUsageTimer.Start();
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Intended to work on Windows only at this time.")]
         private static int GetCPUUsage()
         {
             using PerformanceCounter perfCounter = new(categoryName: CategoryName, counterName: CounterName, instanceName: InstanceName);

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/ShowCPUUsage.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/ShowCPUUsage.cs
@@ -11,6 +11,14 @@ using System.Threading;
 namespace DeckSurf.Plugin.Barn.Commands
 {
     [CompatibleWith(DeviceModel.XL)]
+    [CompatibleWith(DeviceModel.XL2022)]
+    [CompatibleWith(DeviceModel.Original)]
+    [CompatibleWith(DeviceModel.Original2019)]
+    [CompatibleWith(DeviceModel.MK2)]
+    [CompatibleWith(DeviceModel.Mini)]
+    [CompatibleWith(DeviceModel.Mini2022)]
+    [CompatibleWith(DeviceModel.Plus)]
+    [CompatibleWith(DeviceModel.Neo)]
     class ShowCPUUsage : IDeckSurfCommand
     {
         private const string CategoryName = "Processor";

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/ShowCPUUsage.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/ShowCPUUsage.cs
@@ -4,10 +4,8 @@ using DeckSurf.SDK.Models;
 using DeckSurf.SDK.Util;
 using System;
 using System.Diagnostics;
-using System.Drawing;
 using System.IO;
-using System.Runtime.Versioning;
-using System.Threading;
+using System.Runtime.InteropServices;
 
 namespace DeckSurf.Plugin.Barn.Commands
 {
@@ -20,21 +18,15 @@ namespace DeckSurf.Plugin.Barn.Commands
     [CompatibleWith(DeviceModel.Mini2022)]
     [CompatibleWith(DeviceModel.Plus)]
     [CompatibleWith(DeviceModel.Neo)]
-    [SupportedOSPlatform("windows")]
     class ShowCPUUsage : IDeckSurfCommand
     {
-        private const string CategoryName = "Processor";
-        private const string CounterName = "% Processor Time";
-        private const string InstanceName = "_Total";
-
         private System.Timers.Timer _cpuUsageTimer;
 
         public string Name => "Show CPU Usage";
-        public string Description => "Displays live CPU usage percentage on a Stream Deck button. Windows only.";
+        public string Description => "Displays live CPU usage percentage on a Stream Deck button.";
 
         public void ExecuteOnAction(CommandMapping mappedCommand, IConnectedDevice mappedDevice, int activatingButton = -1)
         {
-
         }
 
         public void ExecuteOnActivation(CommandMapping mappedCommand, IConnectedDevice mappedDevice)
@@ -44,18 +36,17 @@ namespace DeckSurf.Plugin.Barn.Commands
             {
                 try
                 {
-                    using var randomIconFromText = IconGenerator.GenerateTestImageFromText(GetCPUUsage().ToString() + "%", new Font("Bahnschrift", 94), Color.Red, Color.Black);
+                    int cpuUsage = CpuMonitor.GetSystemCpuUsage();
+                    if (cpuUsage < 0) return;
 
-                    byte[] byteContent;
-                    using (var ms = new MemoryStream())
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
-                        randomIconFromText.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
-                        byteContent = ms.ToArray();
+                        RenderTextButton(cpuUsage, mappedCommand, mappedDevice);
                     }
-
-                    var resizeImage = ImageHelper.ResizeImage(byteContent, mappedDevice.ButtonResolution, mappedDevice.ButtonResolution, mappedDevice.ImageRotation, mappedDevice.KeyImageFormat);
-
-                    mappedDevice.SetKey(mappedCommand.ButtonIndex, resizeImage);
+                    else
+                    {
+                        RenderColorButton(cpuUsage, mappedCommand, mappedDevice);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -65,14 +56,59 @@ namespace DeckSurf.Plugin.Barn.Commands
             _cpuUsageTimer.Start();
         }
 
-        private static int GetCPUUsage()
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        private static void RenderTextButton(int cpuUsage, CommandMapping mappedCommand, IConnectedDevice mappedDevice)
         {
-            using PerformanceCounter perfCounter = new(categoryName: CategoryName, counterName: CounterName, instanceName: InstanceName);
-            // Dummy call because PerformanceCounter will always start with zero.
-            perfCounter.NextValue();
-            Thread.Sleep(1000);
-            var targetCPUUsage = (int)Math.Round(perfCounter.NextValue());
-            return targetCPUUsage;
+            using var image = IconGenerator.GenerateTestImageFromText(
+                cpuUsage + "%",
+                new System.Drawing.Font("Bahnschrift", 94),
+                System.Drawing.Color.Red,
+                System.Drawing.Color.Black);
+
+            byte[] byteContent;
+            using (var ms = new MemoryStream())
+            {
+                image.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                byteContent = ms.ToArray();
+            }
+
+            var resized = ImageHelper.ResizeImage(
+                byteContent,
+                mappedDevice.ButtonResolution,
+                mappedDevice.ButtonResolution,
+                mappedDevice.ImageRotation,
+                mappedDevice.KeyImageFormat);
+
+            mappedDevice.SetKey(mappedCommand.ButtonIndex, resized);
+        }
+
+        private static void RenderColorButton(int cpuUsage, CommandMapping mappedCommand, IConnectedDevice mappedDevice)
+        {
+            // Map CPU usage to a green (low) -> yellow (mid) -> red (high) gradient.
+            var color = CpuUsageToColor(cpuUsage);
+            mappedDevice.SetKeyColor(mappedCommand.ButtonIndex, color);
+        }
+
+        private static DeviceColor CpuUsageToColor(int percent)
+        {
+            percent = Math.Clamp(percent, 0, 100);
+
+            // 0% = green (0,180,0), 50% = yellow (255,200,0), 100% = red (255,0,0)
+            byte r, g, b = 0;
+            if (percent <= 50)
+            {
+                double t = percent / 50.0;
+                r = (byte)(t * 255);
+                g = (byte)(180 + t * 20);
+            }
+            else
+            {
+                double t = (percent - 50) / 50.0;
+                r = 255;
+                g = (byte)(200 * (1 - t));
+            }
+
+            return new DeviceColor(r, g, b);
         }
 
         public void Dispose()

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/ShowCPUUsage.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/ShowCPUUsage.cs
@@ -66,7 +66,7 @@ namespace DeckSurf.Plugin.Barn.Commands
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Intended to work on Windows only at this time.")]
         private static int GetCPUUsage()
         {
-            PerformanceCounter perfCounter = new(categoryName: CategoryName, counterName: CounterName, instanceName: InstanceName);
+            using PerformanceCounter perfCounter = new(categoryName: CategoryName, counterName: CounterName, instanceName: InstanceName);
             // Dummy call because PerformanceCounter will always start with zero.
             perfCounter.NextValue();
             Thread.Sleep(1000);

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/SnakeGame.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/SnakeGame.cs
@@ -28,8 +28,8 @@ namespace DeckSurf.Plugin.Barn.Commands
         private int _head;
         private Timer _timer;
         private readonly object _lock = new();
-        private int _columns;
-        private int _rows;
+        private int _columns = 8;
+        private int _rows = 4;
 
         public SnakeGame()
         {

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/SnakeGame.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/SnakeGame.cs
@@ -9,6 +9,14 @@ using System.Timers;
 namespace DeckSurf.Plugin.Barn.Commands
 {
     [CompatibleWith(DeviceModel.XL)]
+    [CompatibleWith(DeviceModel.XL2022)]
+    [CompatibleWith(DeviceModel.Original)]
+    [CompatibleWith(DeviceModel.Original2019)]
+    [CompatibleWith(DeviceModel.MK2)]
+    [CompatibleWith(DeviceModel.Mini)]
+    [CompatibleWith(DeviceModel.Mini2022)]
+    [CompatibleWith(DeviceModel.Plus)]
+    [CompatibleWith(DeviceModel.Neo)]
     class SnakeGame : IDeckSurfCommand
     {
         public string Name => "Snake Game";

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/SnakeGame.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/SnakeGame.cs
@@ -34,12 +34,6 @@ namespace DeckSurf.Plugin.Barn.Commands
         public SnakeGame()
         {
             _snake = new();
-            _snake.Enqueue(0);
-            _snake.Enqueue(1);
-            _snake.Enqueue(2);
-            _snake.Enqueue(3);
-            _head = 3;
-
             _direction = SnakeDirection.RIGHT;
         }
 
@@ -90,6 +84,15 @@ namespace DeckSurf.Plugin.Barn.Commands
         {
             _columns = mappedDevice.ButtonColumns;
             _rows = mappedDevice.ButtonRows;
+
+            // Initialize the snake to fit within the first row of the device.
+            _snake.Clear();
+            var initialLength = Math.Min(3, _columns);
+            for (int i = 0; i < initialLength; i++)
+            {
+                _snake.Enqueue(i);
+            }
+            _head = initialLength - 1;
 
             mappedDevice.ClearButtons();
 

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/SnakeGame.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Commands/SnakeGame.cs
@@ -21,7 +21,7 @@ namespace DeckSurf.Plugin.Barn.Commands
     {
         public string Name => "Snake Game";
 
-        public string Description => "A simple game of snake that can be played on Stream Deck.";
+        public string Description => "Plays a game of snake on the Stream Deck button grid.";
 
         private Queue<int> _snake;
         private SnakeDirection _direction;

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Helpers/CpuMonitor.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Helpers/CpuMonitor.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace DeckSurf.Plugin.Barn.Helpers
+{
+    /// <summary>
+    /// Cross-platform system-wide CPU usage measurement.
+    /// </summary>
+    internal static class CpuMonitor
+    {
+        /// <summary>
+        /// Returns system-wide CPU usage as a percentage (0-100).
+        /// Blocks for a short interval to sample CPU counters.
+        /// Returns -1 if measurement fails on the current platform.
+        /// </summary>
+        internal static int GetSystemCpuUsage()
+        {
+            try
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return GetWindowsCpuUsage();
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    return GetLinuxCpuUsage();
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    return GetMacOSCpuUsage();
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"CPU measurement failed: {ex.Message}");
+            }
+
+            return -1;
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static int GetWindowsCpuUsage()
+        {
+            using var perfCounter = new PerformanceCounter("Processor", "% Processor Time", "_Total");
+            // First call always returns zero — it establishes the baseline.
+            perfCounter.NextValue();
+            Thread.Sleep(500);
+            return (int)Math.Round(perfCounter.NextValue());
+        }
+
+        private static int GetLinuxCpuUsage()
+        {
+            var first = ReadLinuxProcStat();
+            Thread.Sleep(500);
+            var second = ReadLinuxProcStat();
+
+            long totalDelta = second.total - first.total;
+            if (totalDelta == 0) return 0;
+
+            long idleDelta = second.idle - first.idle;
+            return (int)((totalDelta - idleDelta) * 100 / totalDelta);
+        }
+
+        private static (long idle, long total) ReadLinuxProcStat()
+        {
+            var lines = File.ReadAllLines("/proc/stat");
+            var cpuLine = lines.FirstOrDefault(l => l.StartsWith("cpu "));
+            if (cpuLine == null)
+            {
+                throw new InvalidOperationException("/proc/stat does not contain an aggregate cpu line.");
+            }
+
+            var parts = cpuLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            // parts[0] = "cpu", parts[1..] = user nice system idle iowait irq softirq steal ...
+            var values = parts.Skip(1).Select(long.Parse).ToArray();
+            if (values.Length < 5)
+            {
+                throw new InvalidOperationException("/proc/stat cpu line has unexpected format.");
+            }
+
+            long idle = values[3] + values[4]; // idle + iowait
+            long total = values.Sum();
+            return (idle, total);
+        }
+
+        private static int GetMacOSCpuUsage()
+        {
+            // Run top for two samples — the first is cumulative since boot,
+            // the second is the delta over the sampling interval.
+            var psi = new ProcessStartInfo("top", "-l 2 -n 0 -s 1")
+            {
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using var proc = Process.Start(psi);
+            if (proc == null)
+            {
+                return -1;
+            }
+
+            var output = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
+
+            // Parse the last "CPU usage:" line for the delta sample.
+            var matches = Regex.Matches(output, @"CPU usage:\s+([\d.]+)% user,\s+([\d.]+)% sys");
+            if (matches.Count < 2)
+            {
+                return -1;
+            }
+
+            var lastMatch = matches[matches.Count - 1];
+            double user = double.Parse(lastMatch.Groups[1].Value);
+            double sys = double.Parse(lastMatch.Groups[2].Value);
+            return (int)Math.Round(user + sys);
+        }
+    }
+}

--- a/src/DeckSurf/DeckSurf.Plugin.Barn/Plugin.cs
+++ b/src/DeckSurf/DeckSurf.Plugin.Barn/Plugin.cs
@@ -12,8 +12,8 @@ namespace DeckSurf.Plugin.Barn
         {
             Author = "Den Delimarsky",
             Id = "DeckSurf.Plugin.Barn",
-            Version = "0.0.1-alpha",
-            Website = "https://github.com/dend/piglet"
+            Version = "0.0.2",
+            Website = "https://github.com/dend/decksurf"
         };
 
         public PluginMetadata Metadata

--- a/src/DeckSurf/DeckSurf/DeckSurf.csproj
+++ b/src/DeckSurf/DeckSurf/DeckSurf.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="DeckSurf.SDK" Version="0.0.7" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
 </Project>

--- a/src/DeckSurf/DeckSurf/DeckSurf.csproj
+++ b/src/DeckSurf/DeckSurf/DeckSurf.csproj
@@ -8,7 +8,7 @@
     <ApplicationIcon>piglet.ico</ApplicationIcon>
     <Authors>Den Delimarsky</Authors>
     <Version>0.0.2</Version>
-    <Copyright>2021-2026 Den Delimarsky. All rights reserved.</Copyright>
+    <Copyright>2026 Den Delimarsky. All rights reserved.</Copyright>
     <AssemblyName>deck</AssemblyName>
 
     <!-- .NET Global Tool configuration -->

--- a/src/DeckSurf/DeckSurf/DeckSurf.csproj
+++ b/src/DeckSurf/DeckSurf/DeckSurf.csproj
@@ -8,7 +8,7 @@
     <ApplicationIcon>piglet.ico</ApplicationIcon>
     <Authors>Den Delimarsky</Authors>
     <Version>0.0.2</Version>
-    <Copyright>2021 by Den Delimarsky. All rights reserved.</Copyright>
+    <Copyright>2021-2026 Den Delimarsky. All rights reserved.</Copyright>
     <AssemblyName>deck</AssemblyName>
 
     <!-- .NET Global Tool configuration -->

--- a/src/DeckSurf/DeckSurf/DeckSurf.csproj
+++ b/src/DeckSurf/DeckSurf/DeckSurf.csproj
@@ -10,6 +10,16 @@
     <Version>0.0.2</Version>
     <Copyright>2021 by Den Delimarsky. All rights reserved.</Copyright>
     <AssemblyName>deck</AssemblyName>
+
+    <!-- .NET Global Tool configuration -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>deck</ToolCommandName>
+    <PackageId>DeckSurf</PackageId>
+    <Description>Open, hackable CLI for managing Elgato Stream Deck devices.</Description>
+    <PackageProjectUrl>https://github.com/dend/decksurf</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>streamdeck;elgato;hid;cli</PackageTags>
+    <RepositoryUrl>https://github.com/dend/decksurf</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -19,11 +29,15 @@
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="DeckSurf.SDK" Version="0.0.7" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DeckSurf.Plugin.Barn\DeckSurf.Plugin.Barn.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/DeckSurf/DeckSurf/Extensibility/Loader.cs
+++ b/src/DeckSurf/DeckSurf/Extensibility/Loader.cs
@@ -16,16 +16,36 @@ namespace DeckSurf.Extensibility
         {
             Regex assemblyPattern = new Regex(@"DeckSurf\.Plugin\..+\.dll");
 
-            var pluginPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "plugins");
+            var basePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var pluginPath = Path.Combine(basePath, "plugins");
 
-            if (!Directory.Exists(pluginPath))
+            var dllPaths = new List<string>();
+
+            // Scan the plugins/ subdirectory (standard layout for local/dev builds).
+            if (Directory.Exists(pluginPath))
             {
-                Console.Error.WriteLine($"[Warning] Plugins directory not found: {pluginPath}");
-                return Enumerable.Empty<T>();
+                dllPaths.AddRange(
+                    Directory.EnumerateFiles(pluginPath, "*.dll", SearchOption.AllDirectories)
+                        .Where(path => assemblyPattern.IsMatch(Path.GetFileName(path))));
             }
 
-            var dllPaths = Directory.EnumerateFiles(pluginPath, "*.dll", SearchOption.AllDirectories)
-                .Where(path => assemblyPattern.IsMatch(Path.GetFileName(path)));
+            // Also scan the executable's own directory (global tool layout where
+            // all DLLs are side-by-side).
+            dllPaths.AddRange(
+                Directory.EnumerateFiles(basePath, "*.dll", SearchOption.TopDirectoryOnly)
+                    .Where(path => assemblyPattern.IsMatch(Path.GetFileName(path))));
+
+            // Deduplicate by filename in case the same plugin appears in both locations.
+            dllPaths = dllPaths
+                .GroupBy(p => Path.GetFileName(p), StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.First())
+                .ToList();
+
+            if (dllPaths.Count == 0)
+            {
+                Console.Error.WriteLine("[Warning] No plugin assemblies found.");
+                return Enumerable.Empty<T>();
+            }
 
             var assemblies = new List<Assembly>();
             foreach (var dllPath in dllPaths)

--- a/src/DeckSurf/DeckSurf/Program.cs
+++ b/src/DeckSurf/DeckSurf/Program.cs
@@ -6,7 +6,7 @@ using DeckSurf.SDK.Util;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using System.Linq;
 using System.Text.Json;

--- a/src/DeckSurf/DeckSurf/Program.cs
+++ b/src/DeckSurf/DeckSurf/Program.cs
@@ -435,9 +435,17 @@ namespace DeckSurf
 
         private static void HandleProfilesDeleteCommand(string name)
         {
-            var profilesPath = Path.Combine(
+            var profilesRoot = Path.GetFullPath(Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Den.Dev", "DeckSurf", "Profiles", name);
+                "Den.Dev", "DeckSurf", "Profiles"));
+            var profilesPath = Path.GetFullPath(Path.Combine(profilesRoot, name));
+
+            // Prevent path traversal — ensure the resolved path is inside the profiles directory.
+            if (!profilesPath.StartsWith(profilesRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                Console.WriteLine($"Invalid profile name: {name}");
+                return;
+            }
 
             if (!Directory.Exists(profilesPath))
             {

--- a/src/DeckSurf/DeckSurf/Program.cs
+++ b/src/DeckSurf/DeckSurf/Program.cs
@@ -9,6 +9,7 @@ using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,104 +25,62 @@ namespace DeckSurf
 
         private static Task<int> SetupCommandLine(string[] args)
         {
-            var rootCommand = new RootCommand();
+            var rootCommand = new RootCommand("DeckSurf - open, hackable CLI for managing Elgato Stream Deck devices.");
 
-            // Command to write content to the StreamDeck.
-            var writeCommand = new Command("write")
-            {
-                Handler = CommandHandler.Create<int, int, string, string, string, string, string>(HandleWriteCommand)
-            };
+            // ── devices ──
+            var devicesCommand = new Command("devices", "Manage connected Stream Deck devices.");
 
-            writeCommand.AddOption(new Option<int>(
-                   aliases: new[] { "--device-index", "-d" },
-                   getDefaultValue: () => -1,
-                   description: "Index of the connected device, to which a key setting should be written.")
-            {
-                IsRequired = true,
-                AllowMultipleArgumentsPerToken = false
-            });
-
-            writeCommand.AddOption(new Option<int>(
-                   aliases: new[] { "--key-index", "-k" },
-                   getDefaultValue: () => -1,
-                   description: "Index of the key that needs to be written.")
-            {
-                IsRequired = true,
-                AllowMultipleArgumentsPerToken = false
-            });
-
-            writeCommand.AddOption(new Option<string>(
-                   aliases: new[] { "--plugin", "-l" },
-                   getDefaultValue: () => string.Empty,
-                   description: "Plugin that contains the relevant command.")
-            {
-                IsRequired = true,
-                AllowMultipleArgumentsPerToken = false
-            });
-
-            writeCommand.AddOption(new Option<string>(
-                   aliases: new[] { "--command", "-c" },
-                   getDefaultValue: () => string.Empty,
-                   description: "Command to be executed.")
-            {
-                IsRequired = true,
-                AllowMultipleArgumentsPerToken = false
-            });
-
-            writeCommand.AddOption(new Option<string>(
-                   aliases: new[] { "--image-path", "-i" },
-                   getDefaultValue: () => string.Empty,
-                   description: "Path to the default image for the button.")
-            {
-                IsRequired = true,
-                AllowMultipleArgumentsPerToken = false
-            });
-
-            writeCommand.AddOption(new Option<string>(
-                   aliases: new[] { "--action-args", "-g" },
-                   getDefaultValue: () => string.Empty,
-                   description: "Arguments for the defined action.")
-            {
-                IsRequired = true,
-                AllowMultipleArgumentsPerToken = false
-            });
-
-            writeCommand.AddOption(new Option<string>(
-                   aliases: new[] { "--profile", "-p" },
-                   getDefaultValue: () => string.Empty,
-                   description: "The profile to which the command should be added.")
-            {
-                IsRequired = true,
-                AllowMultipleArgumentsPerToken = false
-            });
-
-            // Command to list connected StreamDeck devices.
-            var listCommand = new Command("list")
+            var devicesListCommand = new Command("list", "List all connected Stream Deck devices.")
             {
                 Handler = CommandHandler.Create(HandleListCommand)
             };
 
-            // Command to list all available plug-ins.
-            var listPluginsCommand = new Command("list-plugins")
+            var devicesInfoCommand = new Command("info", "Show detailed information about a connected device.")
             {
-                Handler = CommandHandler.Create(HandleListPluginsCommand)
+                Handler = CommandHandler.Create<int>(HandleDeviceInfoCommand)
             };
+            devicesInfoCommand.AddOption(new Option<int>(
+                   aliases: new[] { "--device-index", "-d" },
+                   getDefaultValue: () => 0,
+                   description: "Zero-based index of the connected device.")
+            {
+                AllowMultipleArgumentsPerToken = false
+            });
 
-            // Command to listen to events from the StreamDeck.
-            var listenCommand = new Command("listen")
+            var devicesBrightnessCommand = new Command("brightness", "Set the brightness level of a connected device.")
             {
-                Handler = CommandHandler.Create<string>(HandleListenCommand)
+                Handler = CommandHandler.Create<int, int>(HandleBrightnessCommand)
             };
-            listenCommand.AddOption(new Option<string>(
-                   aliases: new[] { "--profile", "-p" },
-                   getDefaultValue: () => string.Empty,
-                   description: "The profile associated with the current device.")
+            devicesBrightnessCommand.AddOption(new Option<int>(
+                   aliases: new[] { "--device-index", "-d" },
+                   getDefaultValue: () => 0,
+                   description: "Zero-based index of the connected device.")
+            {
+                AllowMultipleArgumentsPerToken = false
+            });
+            devicesBrightnessCommand.AddOption(new Option<int>(
+                   aliases: new[] { "--level", "-l" },
+                   description: "Brightness level (0-100).")
             {
                 IsRequired = true,
                 AllowMultipleArgumentsPerToken = false
             });
 
-            // Profiles command group.
+            devicesCommand.AddCommand(devicesListCommand);
+            devicesCommand.AddCommand(devicesInfoCommand);
+            devicesCommand.AddCommand(devicesBrightnessCommand);
+
+            // ── plugins ──
+            var pluginsCommand = new Command("plugins", "Manage and inspect available plugins.");
+
+            var pluginsListCommand = new Command("list", "List all available plugins and their commands.")
+            {
+                Handler = CommandHandler.Create(HandleListPluginsCommand)
+            };
+
+            pluginsCommand.AddCommand(pluginsListCommand);
+
+            // ── profiles ──
             var profilesCommand = new Command("profiles", "Manage device profiles.");
 
             var profilesListCommand = new Command("list", "List all available profiles.")
@@ -147,46 +106,95 @@ namespace DeckSurf
             profilesCommand.AddCommand(profilesShowCommand);
             profilesCommand.AddCommand(profilesDeleteCommand);
 
-            // Device info command.
-            var deviceInfoCommand = new Command("info", "Show detailed information about a connected device.")
+            // ── write ──
+            var writeCommand = new Command("write", "Write a button configuration to a profile.")
             {
-                Handler = CommandHandler.Create<int>(HandleDeviceInfoCommand)
+                Handler = CommandHandler.Create<int, int, string, string, string, string, string>(HandleWriteCommand)
             };
-            deviceInfoCommand.AddOption(new Option<int>(
-                   aliases: new[] { "--device-index", "-d" },
-                   getDefaultValue: () => 0,
-                   description: "Index of the connected device.")
-            {
-                AllowMultipleArgumentsPerToken = false
-            });
 
-            // Brightness command.
-            var brightnessCommand = new Command("brightness", "Set the brightness level of a connected device.")
-            {
-                Handler = CommandHandler.Create<int, int>(HandleBrightnessCommand)
-            };
-            brightnessCommand.AddOption(new Option<int>(
+            writeCommand.AddOption(new Option<int>(
                    aliases: new[] { "--device-index", "-d" },
-                   getDefaultValue: () => 0,
-                   description: "Index of the connected device.")
-            {
-                AllowMultipleArgumentsPerToken = false
-            });
-            brightnessCommand.AddOption(new Option<int>(
-                   aliases: new[] { "--level", "-b" },
-                   description: "Brightness level (0-100).")
+                   getDefaultValue: () => -1,
+                   description: "Zero-based index of the connected device.")
             {
                 IsRequired = true,
                 AllowMultipleArgumentsPerToken = false
             });
 
-            rootCommand.AddCommand(writeCommand);
-            rootCommand.AddCommand(listCommand);
-            rootCommand.AddCommand(listPluginsCommand);
-            rootCommand.AddCommand(listenCommand);
+            writeCommand.AddOption(new Option<int>(
+                   aliases: new[] { "--key-index", "-k" },
+                   getDefaultValue: () => -1,
+                   description: "Zero-based index of the key to configure.")
+            {
+                IsRequired = true,
+                AllowMultipleArgumentsPerToken = false
+            });
+
+            writeCommand.AddOption(new Option<string>(
+                   aliases: new[] { "--plugin", "-n" },
+                   getDefaultValue: () => string.Empty,
+                   description: "Plugin ID (e.g., DeckSurf.Plugin.Barn).")
+            {
+                IsRequired = true,
+                AllowMultipleArgumentsPerToken = false
+            });
+
+            writeCommand.AddOption(new Option<string>(
+                   aliases: new[] { "--command", "-c" },
+                   getDefaultValue: () => string.Empty,
+                   description: "Command class name within the plugin.")
+            {
+                IsRequired = true,
+                AllowMultipleArgumentsPerToken = false
+            });
+
+            writeCommand.AddOption(new Option<string>(
+                   aliases: new[] { "--image-path", "-i" },
+                   getDefaultValue: () => string.Empty,
+                   description: "Path to the default image for the button.")
+            {
+                IsRequired = true,
+                AllowMultipleArgumentsPerToken = false
+            });
+
+            writeCommand.AddOption(new Option<string>(
+                   aliases: new[] { "--action-args", "-a" },
+                   getDefaultValue: () => string.Empty,
+                   description: "Arguments passed to the command.")
+            {
+                IsRequired = true,
+                AllowMultipleArgumentsPerToken = false
+            });
+
+            writeCommand.AddOption(new Option<string>(
+                   aliases: new[] { "--profile", "-p" },
+                   getDefaultValue: () => string.Empty,
+                   description: "Profile name. Created if it does not exist.")
+            {
+                IsRequired = true,
+                AllowMultipleArgumentsPerToken = false
+            });
+
+            // ── listen ──
+            var listenCommand = new Command("listen", "Start listening for button presses on a configured profile.")
+            {
+                Handler = CommandHandler.Create<string>(HandleListenCommand)
+            };
+            listenCommand.AddOption(new Option<string>(
+                   aliases: new[] { "--profile", "-p" },
+                   getDefaultValue: () => string.Empty,
+                   description: "The profile to activate.")
+            {
+                IsRequired = true,
+                AllowMultipleArgumentsPerToken = false
+            });
+
+            // ── register commands ──
+            rootCommand.AddCommand(devicesCommand);
+            rootCommand.AddCommand(pluginsCommand);
             rootCommand.AddCommand(profilesCommand);
-            rootCommand.AddCommand(deviceInfoCommand);
-            rootCommand.AddCommand(brightnessCommand);
+            rootCommand.AddCommand(writeCommand);
+            rootCommand.AddCommand(listenCommand);
 
             return rootCommand.InvokeAsync(args);
         }
@@ -194,6 +202,12 @@ namespace DeckSurf
         private static void HandleListPluginsCommand()
         {
             var plugins = Loader.Load<IDeckSurfPlugin>();
+
+            if (!plugins.Any())
+            {
+                Console.WriteLine("No plugins found. Ensure plugin DLLs are in the plugins/ directory.");
+                return;
+            }
 
             Console.WriteLine($"{"Plugin ID",-25} {"Version",-12} {"Author",-15}");
             Console.WriteLine(new string('-', 52));
@@ -257,14 +271,13 @@ namespace DeckSurf
                     }
                 };
 
-                // With a detected device, let's load the plugins
-                // and the associated commands.
                 foreach (var plugin in plugins)
                 {
                     commands.Add(plugin.Metadata.Id.ToLower(), Loader.LoadCommands(plugin, device.Model));
                 }
 
                 device.StartListening();
+                Console.WriteLine($"Listening on profile '{profile}'. Press Ctrl+C to stop.");
 
                 foreach (var mappedButton in workingProfile.ButtonMap)
                 {
@@ -284,7 +297,6 @@ namespace DeckSurf
             }
             finally
             {
-                // Dispose all command instances.
                 foreach (var commandGroup in commands.Values)
                 {
                     foreach (var command in commandGroup)
@@ -296,7 +308,6 @@ namespace DeckSurf
                     }
                 }
 
-                // Dispose the device.
                 if (device is IDisposable disposableDevice)
                 {
                     disposableDevice.Dispose();
@@ -321,17 +332,23 @@ namespace DeckSurf
         private static void HandleListCommand()
         {
             var devices = DeviceManager.GetDeviceList();
-            Console.WriteLine($"{"| Device Name",-21} {"| VID",-10} {"| Serial",-20} {"| Model",-15}");
-            Console.WriteLine(new string('=', 66));
+            if (devices.Count == 0)
+            {
+                Console.WriteLine("No Stream Deck devices found.");
+                Console.WriteLine("Make sure your device is connected and the Elgato Stream Deck software is closed.");
+                return;
+            }
+
+            Console.WriteLine($"{"Device Name",-20} {"VID",-10} {"Serial",-20} {"Model",-15}");
+            Console.WriteLine(new string('-', 65));
             foreach (var device in devices)
             {
-                Console.WriteLine($"{"| " + device.Name,-21} {"| " + device.VendorId,-10} {"| " + device.Serial,-20} {"| " + device.Model,-15}");
+                Console.WriteLine($"{device.Name,-20} {device.VendorId,-10} {device.Serial,-20} {device.Model,-15}");
             }
         }
 
         private static void HandleWriteCommand(int deviceIndex, int keyIndex, string plugin, string command, string imagePath, string actionArgs, string profile)
         {
-            // Validate image path if provided.
             if (!string.IsNullOrEmpty(imagePath) && !File.Exists(imagePath))
             {
                 Console.WriteLine($"Image file not found: {imagePath}");
@@ -357,15 +374,19 @@ namespace DeckSurf
                     };
 
                     ConfigurationHelper.WriteToConfiguration(profile, deviceIndex, mapping);
+                    Console.WriteLine($"Button {keyIndex} configured on profile '{profile}'.");
+                    Console.WriteLine($"Run 'deck listen -p {profile}' to activate.");
                 }
                 else
                 {
-                    Console.WriteLine($"Could not find the {command} associated with {plugin}.");
+                    Console.WriteLine($"Command '{command}' not found in plugin '{plugin}'.");
+                    Console.WriteLine("Run 'deck plugins list' to see available commands.");
                 }
             }
             else
             {
-                Console.WriteLine($"Could not find the {plugin} plugin.");
+                Console.WriteLine($"Plugin '{plugin}' not found.");
+                Console.WriteLine("Run 'deck plugins list' to see available plugins.");
             }
         }
 
@@ -377,14 +398,14 @@ namespace DeckSurf
 
             if (!Directory.Exists(profilesPath))
             {
-                Console.WriteLine("No profiles directory found.");
+                Console.WriteLine("No profiles found. Use 'deck write' to create one.");
                 return;
             }
 
             var directories = Directory.GetDirectories(profilesPath);
             if (directories.Length == 0)
             {
-                Console.WriteLine("No profiles found.");
+                Console.WriteLine("No profiles found. Use 'deck write' to create one.");
                 return;
             }
 
@@ -440,7 +461,6 @@ namespace DeckSurf
                 "Den.Dev", "DeckSurf", "Profiles"));
             var profilesPath = Path.GetFullPath(Path.Combine(profilesRoot, name));
 
-            // Prevent path traversal — ensure the resolved path is inside the profiles directory.
             if (!profilesPath.StartsWith(profilesRoot, StringComparison.OrdinalIgnoreCase))
             {
                 Console.WriteLine($"Invalid profile name: {name}");
@@ -463,7 +483,8 @@ namespace DeckSurf
             var devices = DeviceManager.GetDeviceList();
             if (devices.Count == 0)
             {
-                Console.WriteLine("No connected devices found.");
+                Console.WriteLine("No Stream Deck devices found.");
+                Console.WriteLine("Make sure your device is connected and the Elgato Stream Deck software is closed.");
                 return;
             }
 
@@ -476,17 +497,17 @@ namespace DeckSurf
             var device = devices[deviceIndex];
             Console.WriteLine("Device Information:");
             Console.WriteLine(new string('-', 35));
-            Console.WriteLine($"  Name:             {device.Name}");
-            Console.WriteLine($"  Serial:           {device.Serial}");
-            Console.WriteLine($"  Model:            {device.Model}");
-            Console.WriteLine($"  Button Count:     {device.ButtonCount}");
-            Console.WriteLine($"  Button Layout:    {device.ButtonColumns} x {device.ButtonRows}");
-            Console.WriteLine($"  Button Resolution:{device.ButtonResolution}");
-            Console.WriteLine($"  Screen Supported: {device.IsScreenSupported}");
+            Console.WriteLine($"  Name:              {device.Name}");
+            Console.WriteLine($"  Serial:            {device.Serial}");
+            Console.WriteLine($"  Model:             {device.Model}");
+            Console.WriteLine($"  Button Count:      {device.ButtonCount}");
+            Console.WriteLine($"  Button Layout:     {device.ButtonColumns} x {device.ButtonRows}");
+            Console.WriteLine($"  Button Resolution: {device.ButtonResolution}");
+            Console.WriteLine($"  Screen Supported:  {device.IsScreenSupported}");
             if (device.IsScreenSupported)
             {
-                Console.WriteLine($"  Screen Width:     {device.ScreenWidth}");
-                Console.WriteLine($"  Screen Height:    {device.ScreenHeight}");
+                Console.WriteLine($"  Screen Width:      {device.ScreenWidth}");
+                Console.WriteLine($"  Screen Height:     {device.ScreenHeight}");
             }
         }
 
@@ -501,7 +522,8 @@ namespace DeckSurf
             var devices = DeviceManager.GetDeviceList();
             if (devices.Count == 0)
             {
-                Console.WriteLine("No connected devices found.");
+                Console.WriteLine("No Stream Deck devices found.");
+                Console.WriteLine("Make sure your device is connected and the Elgato Stream Deck software is closed.");
                 return;
             }
 

--- a/src/DeckSurf/Directory.Build.props
+++ b/src/DeckSurf/Directory.Build.props
@@ -4,6 +4,8 @@
     <Copyright>2021-2026 Den Delimarsky. All rights reserved.</Copyright>
     <Nullable>disable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/DeckSurf/Directory.Build.props
+++ b/src/DeckSurf/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Company>Den Delimarsky</Company>
-    <Copyright>2021-2026 Den Delimarsky. All rights reserved.</Copyright>
+    <Copyright>2026 Den Delimarsky. All rights reserved.</Copyright>
     <Nullable>disable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/src/DeckSurf/Directory.Build.props
+++ b/src/DeckSurf/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Company>Den Delimarsky</Company>
     <Copyright>2021-2026 Den Delimarsky. All rights reserved.</Copyright>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Fix build by adding `System.CommandLine.NamingConventionBinder` package (CommandHandler.Create moved there in beta4)
- Add CI workflows matching decksurf-sdk patterns: PR validation, main branch build, and tag-based NuGet publishing
- Package DeckSurf as a .NET global tool (`dotnet tool install -g DeckSurf`) with Barn plugin included
- Make LaunchApplication command cross-platform (Windows icon extraction behind platform guard, fallback for other OSes)
- Make all Barn commands compatible with all 9 supported Stream Deck models
- Update project motivation and add Barn plugin documentation with usage examples to README
- Fix SnakeGame divide-by-zero when columns/rows uninitialized, PerformanceCounter resource leak, and other cleanup

## Test plan
- [ ] Verify PR validation workflow passes on ubuntu-latest
- [ ] Verify `dotnet pack` produces a valid .nupkg with Barn plugin included
- [ ] Verify `dotnet tool install` from local nupkg makes `deck` available globally
- [ ] Verify LaunchApplication works on Windows (with icon extraction) and Linux/macOS (fallback)
- [ ] Verify SnakeGame initializes correctly on all device models

🤖 Generated with [Claude Code](https://claude.com/claude-code)